### PR TITLE
Make liquibase tables cluster replicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Your updates should also affect the entire cluster either by using ON CLUSTER cl
 <hr/>
 
 ###### Important changes
-From the version 0.7.1 the liquibase-clickhouse supports replication on a cluster. 
+From the version 0.7.0 the liquibase-clickhouse supports replication on a cluster. 
 
 From the version 0.6.0 the extension adapted for the liquibase v4.3.5.
 

--- a/README.md
+++ b/README.md
@@ -13,4 +13,22 @@ Maven dependency:
 </dependency>
 ```
 
-Note: From the version 0.6.0 the extension is adapted for the liquibase v4.3.5.
+The cluster mode can be activated by adding the **_liquibaseClickhouse.conf_** file to the classpath (liquibase/lib/).
+```
+cluster {
+    clusterName="{cluster}"
+    tableZooKeeperPathPrefix="/clickhouse/tables/{shard}/{database}/"
+    tableReplicaName="{replica}"
+}
+```
+In this mode, liquibase will create its own tables as replicated.<br/>
+All changes in these files will be replicated on the entire cluster.<br/>
+Your updates should also affect the entire cluster either by using ON CLUSTER clause, or by using replicated tables.
+
+<hr/>
+
+###### Important changes
+From the version 0.7.1 the liquibase-clickhouse supports replication on a cluster. 
+
+From the version 0.6.0 the extension adapted for the liquibase v4.3.5.
+

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.mediarithmics</groupId>
     <artifactId>liquibase-clickhouse</artifactId>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <inceptionYear>2020</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,8 @@
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <snakeyaml.version>1.28</snakeyaml.version>
+        <typesafe-config.version>1.4.1</typesafe-config.version>
     </properties>
 
     <dependencies>
@@ -113,15 +115,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.30</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.28</version>
+            <version>${snakeyaml.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>${typesafe-config.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
+++ b/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
@@ -24,12 +24,18 @@ import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
 import ru.yandex.clickhouse.ClickHouseDriver;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 public class ClickHouseDatabase extends AbstractJdbcDatabase {
 
   private static final String DATABASE_NAME = "ClickHouse";
   private static final int DEFAULT_PORT = 8123;
   private static final String DRIVER_CLASS_NAME = ClickHouseDriver.class.getName();
-  private static final String CURRENT_DATE_TIME_FUNCTION = "now()";
+  public static final String CURRENT_DATE_TIME_FUNCTION =
+      "toDateTime64('"
+          + new SimpleDateFormat("yyyy.MM.dd HH:mm:ss.SSS").format(new Date())
+          + "',3)";
 
   public ClickHouseDatabase() {
     super();

--- a/src/main/java/liquibase/ext/clickhouse/params/ClusterConfig.java
+++ b/src/main/java/liquibase/ext/clickhouse/params/ClusterConfig.java
@@ -1,0 +1,40 @@
+package liquibase.ext.clickhouse.params;
+
+public class ClusterConfig {
+  private String clusterName;
+  private String tableZooKeeperPathPrefix;
+  private String tableReplicaName;
+
+  public ClusterConfig() {}
+
+  public ClusterConfig(
+      String clusterName, String tableZooKeeperPathPrefix, String tableReplicaName) {
+    this.clusterName = clusterName;
+    this.tableZooKeeperPathPrefix = tableZooKeeperPathPrefix;
+    this.tableReplicaName = tableReplicaName;
+  }
+
+  public String getClusterName() {
+    return clusterName;
+  }
+
+  public void setClusterName(String clusterName) {
+    this.clusterName = clusterName;
+  }
+
+  public String getTableZooKeeperPathPrefix() {
+    return tableZooKeeperPathPrefix;
+  }
+
+  public void setTableZooKeeperPathPrefix(String tableZooKeeperPathPrefix) {
+    this.tableZooKeeperPathPrefix = tableZooKeeperPathPrefix;
+  }
+
+  public String getTableReplicaName() {
+    return tableReplicaName;
+  }
+
+  public void setTableReplicaName(String tableReplicaName) {
+    this.tableReplicaName = tableReplicaName;
+  }
+}

--- a/src/main/java/liquibase/ext/clickhouse/params/ParamsLoader.java
+++ b/src/main/java/liquibase/ext/clickhouse/params/ParamsLoader.java
@@ -1,0 +1,101 @@
+package liquibase.ext.clickhouse.params;
+
+import java.io.*;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigValue;
+import liquibase.logging.Logger;
+import liquibase.Scope;
+import com.typesafe.config.ConfigFactory;
+import java.util.*;
+
+public class ParamsLoader {
+  private static final Logger LOG = Scope.getCurrentScope().getLog(ParamsLoader.class);
+
+  private static ClusterConfig liquibaseClickhouseProperties = null;
+
+  private static Set<String> validProperties =
+      new HashSet<>(Arrays.asList("clusterName", "tableZooKeeperPathPrefix", "tableReplicaName"));
+
+  private static StringBuilder appendWithComma(StringBuilder sb, String text) {
+    if (sb.length() > 0) sb.append(", ");
+    sb.append(text);
+
+    return sb;
+  }
+
+  private static String getMissingProperties(Set<String> properties) {
+    StringBuilder missingProperties = new StringBuilder();
+    for (String validProperty : validProperties)
+      if (!properties.contains(validProperty)) appendWithComma(missingProperties, validProperty);
+
+    return missingProperties.toString();
+  }
+
+  private static void checkProperties(Map<String, String> properties)
+      throws InvalidPropertiesFormatException {
+    StringBuilder errMsg = new StringBuilder();
+
+    for (String key : properties.keySet())
+      if (!validProperties.contains(key)) {
+        appendWithComma(errMsg, "unknown property: ").append(key);
+      }
+
+    if (errMsg.length() > 0 || properties.size() != validProperties.size()) {
+      appendWithComma(errMsg, "the missing properties should be defined: ");
+      errMsg.append(getMissingProperties(properties.keySet()));
+    }
+
+    if (errMsg.length() > 0) throw new InvalidPropertiesFormatException(errMsg.toString());
+  }
+
+  private static String getStackTrace(Exception e) {
+    StringWriter sw = new StringWriter();
+    PrintWriter pw = new PrintWriter(sw);
+    e.printStackTrace(pw);
+
+    return sw.toString();
+  }
+
+  public static ClusterConfig getLiquibaseClickhouseProperties() {
+    return getLiquibaseClickhouseProperties("liquibaseClickhouse");
+  }
+
+  public static ClusterConfig getLiquibaseClickhouseProperties(String configFile) {
+    if (liquibaseClickhouseProperties != null) return liquibaseClickhouseProperties;
+
+    Config conf = ConfigFactory.load(configFile);
+    Map<String, String> params = new HashMap<>();
+    ClusterConfig result = null;
+
+    try {
+      for (Map.Entry<String, ConfigValue> s : conf.getConfig("cluster").entrySet())
+        params.put(s.getKey(), s.getValue().unwrapped().toString());
+
+      checkProperties(params);
+      result =
+          new ClusterConfig(
+              params.get("clusterName"),
+              params.get("tableZooKeeperPathPrefix"),
+              params.get("tableReplicaName"));
+
+      LOG.info(
+          "Cluster settings ("
+              + configFile
+              + ".conf) are found. Work in cluster replicated clickhouse mode.");
+    } catch (ConfigException.Missing e) {
+      LOG.info(
+          "Cluster settings ("
+              + configFile
+              + ".conf) are not defined. Work in single-instance clickhouse mode.");
+      LOG.info(
+          "The following properties should be defined: " + getMissingProperties(new HashSet<>()));
+    } catch (InvalidPropertiesFormatException e) {
+      LOG.severe(getStackTrace(e));
+      LOG.severe("Work in single-instance clickhouse mode.");
+    }
+
+    return result;
+  }
+}

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/InitializeDatabaseChangeLogLockClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/InitializeDatabaseChangeLogLockClickHouse.java
@@ -22,6 +22,8 @@ package liquibase.ext.clickhouse.sqlgenerator;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
 
 import liquibase.database.Database;
+import liquibase.ext.clickhouse.params.ClusterConfig;
+import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.InitializeDatabaseChangeLogLockTableGenerator;
@@ -46,10 +48,16 @@ public class InitializeDatabaseChangeLogLockClickHouse
       InitializeDatabaseChangeLogLockTableStatement statement,
       Database database,
       SqlGeneratorChain sqlGeneratorChain) {
+    ClusterConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+
     String clearDatabaseQuery =
         String.format(
-            "ALTER TABLE %s.%s DELETE WHERE 1",
-            database.getDefaultSchemaName(), database.getDatabaseChangeLogLockTableName());
+            "ALTER TABLE %s.%s "
+                + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
+                + "DELETE WHERE 1",
+            database.getDefaultSchemaName(),
+            database.getDatabaseChangeLogLockTableName());
+
     String initLockQuery =
         String.format(
             "INSERT INTO %s.%s (ID, LOCKED) VALUES (1, 0)",

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
@@ -47,8 +47,8 @@ public class LockDatabaseChangeLogClickHouse extends LockDatabaseChangeLogGenera
     String host = String.format("%s %s (%s)", hostname, hostDescription, hostaddress);
     String lockQuery =
         String.format(
-            "ALTER TABLE %s.%s UPDATE LOCKED = 1,LOCKEDBY = '%s',LOCKGRANTED = now() WHERE ID = 1 AND LOCKED = 0",
-            database.getDefaultSchemaName(), database.getDatabaseChangeLogLockTableName(), host);
+            "ALTER TABLE %s.%s UPDATE LOCKED = 1,LOCKEDBY = '%s',LOCKGRANTED = %s WHERE ID = 1 AND LOCKED = 0",
+            database.getDefaultSchemaName(), database.getDatabaseChangeLogLockTableName(), host, ClickHouseDatabase.CURRENT_DATE_TIME_FUNCTION);
     return SqlGeneratorUtil.generateSql(database, lockQuery);
   }
 }

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
@@ -22,6 +22,8 @@ package liquibase.ext.clickhouse.sqlgenerator;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
 
 import liquibase.database.Database;
+import liquibase.ext.clickhouse.params.ClusterConfig;
+import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.LockDatabaseChangeLogGenerator;
@@ -44,11 +46,19 @@ public class LockDatabaseChangeLogClickHouse extends LockDatabaseChangeLogGenera
       LockDatabaseChangeLogStatement statement,
       Database database,
       SqlGeneratorChain sqlGeneratorChain) {
+    ClusterConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+
     String host = String.format("%s %s (%s)", hostname, hostDescription, hostaddress);
     String lockQuery =
         String.format(
-            "ALTER TABLE %s.%s UPDATE LOCKED = 1,LOCKEDBY = '%s',LOCKGRANTED = %s WHERE ID = 1 AND LOCKED = 0",
-            database.getDefaultSchemaName(), database.getDatabaseChangeLogLockTableName(), host, ClickHouseDatabase.CURRENT_DATE_TIME_FUNCTION);
+            "ALTER TABLE %s.%s "
+                + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
+                + "UPDATE LOCKED = 1,LOCKEDBY = '%s',LOCKGRANTED = %s WHERE ID = 1 AND LOCKED = 0",
+            database.getDefaultSchemaName(),
+            database.getDatabaseChangeLogLockTableName(),
+            host,
+            ClickHouseDatabase.CURRENT_DATE_TIME_FUNCTION);
+
     return SqlGeneratorUtil.generateSql(database, lockQuery);
   }
 }

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/RemoveChangeSetRanStatusClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/RemoveChangeSetRanStatusClickHouse.java
@@ -23,6 +23,8 @@ import liquibase.ext.clickhouse.database.ClickHouseDatabase;
 
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
+import liquibase.ext.clickhouse.params.ClusterConfig;
+import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.RemoveChangeSetRanStatusGenerator;
@@ -45,10 +47,14 @@ public class RemoveChangeSetRanStatusClickHouse extends RemoveChangeSetRanStatus
       RemoveChangeSetRanStatusStatement statement,
       Database database,
       SqlGeneratorChain sqlGeneratorChain) {
+    ClusterConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+
     ChangeSet changeSet = statement.getChangeSet();
     String unlockQuery =
         String.format(
-            "ALTER TABLE %s.%s DELETE WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s'",
+            "ALTER TABLE %s.%s "
+                + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
+                + "DELETE WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s'",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogTableName(),
             changeSet.getId(),

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/SqlGeneratorUtil.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/SqlGeneratorUtil.java
@@ -19,11 +19,10 @@
  */
 package liquibase.ext.clickhouse.sqlgenerator;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 import liquibase.database.Database;
+import liquibase.ext.clickhouse.params.ClusterConfig;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorFactory;
 import liquibase.statement.core.RawSqlStatement;
@@ -39,5 +38,19 @@ class SqlGeneratorUtil {
       allSqlStatements.addAll(Arrays.asList(perStatement));
     }
     return allSqlStatements.toArray(new Sql[0]);
+  }
+
+  public static String generateSqlOnClusterClause(ClusterConfig properties) {
+    if (properties != null) return String.format("ON CLUSTER '%s' ", properties.getClusterName());
+    else return " ";
+  }
+
+  public static String generateSqlEngineClause(ClusterConfig properties, String tableName) {
+    if (properties != null)
+      return String.format(
+          "ENGINE ReplicatedMergeTree('%s','%s') ORDER BY ID",
+          properties.getTableZooKeeperPathPrefix() + tableName.toLowerCase(Locale.ROOT),
+          properties.getTableReplicaName());
+    else return "ENGINE MergeTree() ORDER BY ID";
   }
 }

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UnlockDatabaseChangelogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UnlockDatabaseChangelogClickHouse.java
@@ -22,6 +22,8 @@ package liquibase.ext.clickhouse.sqlgenerator;
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
 
 import liquibase.database.Database;
+import liquibase.ext.clickhouse.params.ClusterConfig;
+import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.UnlockDatabaseChangeLogGenerator;
@@ -44,10 +46,16 @@ public class UnlockDatabaseChangelogClickHouse extends UnlockDatabaseChangeLogGe
       UnlockDatabaseChangeLogStatement statement,
       Database database,
       SqlGeneratorChain sqlGeneratorChain) {
+    ClusterConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+
     String unlockQuery =
         String.format(
-            "ALTER TABLE %s.%s UPDATE LOCKED = 0,LOCKEDBY = null, LOCKGRANTED = null WHERE ID = 1 AND LOCKED = 1",
-            database.getDefaultSchemaName(), database.getDatabaseChangeLogLockTableName());
+            "ALTER TABLE %s.%s "
+                + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
+                + "UPDATE LOCKED = 0,LOCKEDBY = null, LOCKGRANTED = null WHERE ID = 1 AND LOCKED = 1",
+            database.getDefaultSchemaName(),
+            database.getDatabaseChangeLogLockTableName());
+
     return SqlGeneratorUtil.generateSql(database, unlockQuery);
   }
 }

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UpdateChangeSetChecksumClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UpdateChangeSetChecksumClickHouse.java
@@ -23,6 +23,8 @@ import liquibase.ext.clickhouse.database.ClickHouseDatabase;
 
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
+import liquibase.ext.clickhouse.params.ClusterConfig;
+import liquibase.ext.clickhouse.params.ParamsLoader;
 import liquibase.sql.Sql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
 import liquibase.sqlgenerator.core.UpdateChangeSetChecksumGenerator;
@@ -45,16 +47,21 @@ public class UpdateChangeSetChecksumClickHouse extends UpdateChangeSetChecksumGe
       UpdateChangeSetChecksumStatement statement,
       Database database,
       SqlGeneratorChain sqlGeneratorChain) {
+    ClusterConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+
     ChangeSet changeSet = statement.getChangeSet();
     String updateChecksumQuery =
         String.format(
-            "ALTER TABLE %s.%s UPDATE MD5SUM = '%s' WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s'",
+            "ALTER TABLE %s.%s "
+                + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
+                + "UPDATE MD5SUM = '%s' WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s'",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogTableName(),
             changeSet.generateCheckSum().toString(),
             changeSet.getId(),
             changeSet.getAuthor(),
             changeSet.getFilePath());
+
     return SqlGeneratorUtil.generateSql(database, updateChecksumQuery);
   }
 }

--- a/src/test/java/liquibase/ParamsLoaderTest.java
+++ b/src/test/java/liquibase/ParamsLoaderTest.java
@@ -1,0 +1,24 @@
+package liquibase;
+
+import liquibase.ext.clickhouse.params.ClusterConfig;
+import liquibase.ext.clickhouse.params.ParamsLoader;
+import org.junit.jupiter.api.Test;
+
+public class ParamsLoaderTest {
+
+  @Test
+  void loadParams() {
+    ClusterConfig params = ParamsLoader.getLiquibaseClickhouseProperties("testLiquibaseClickhouse");
+    assert (params != null);
+    assert (params.getClusterName().equals("Cluster1"));
+    assert (params.getTableZooKeeperPathPrefix().equals("Path1"));
+    assert (params.getTableReplicaName().equals("Replica1"));
+  }
+
+  @Test
+  void loadBrokenParams() {
+    ClusterConfig params =
+        ParamsLoader.getLiquibaseClickhouseProperties("testLiquibaseClickhouseBroken");
+    assert (params == null);
+  }
+}

--- a/src/test/resources/testLiquibaseClickhouse.conf
+++ b/src/test/resources/testLiquibaseClickhouse.conf
@@ -1,0 +1,6 @@
+# these are our cluster config values
+cluster {
+    clusterName="Cluster1"
+    tableZooKeeperPathPrefix="Path1"
+    tableReplicaName="Replica1"
+}

--- a/src/test/resources/testLiquibaseClickhouseBroken.conf
+++ b/src/test/resources/testLiquibaseClickhouseBroken.conf
@@ -1,0 +1,6 @@
+# these are our cluster config values
+cluster {
+    clusterName="Cluster1"
+    tableZooKeeperPathPrefix="Path1"
+    tableReplica_Name="Replica1"
+}


### PR DESCRIPTION
Liquibase uses tables `DATABASECHANGELOG` and `DATABASECHANGELOGLOCK` to store the current state (locked/unlocked) and the list of applied migrations. For the case when we want to apply migrations on all nodes of our cluster, liquibase should also replicate its data on each node of the cluster. It permit us to execute our migration scripts on any node and to avoid duplicate executions.
* added reading of `liquibaseClickhouse.conf`, if the file exists in classpath, liquibase uses replication. The file contains cluster-specific parameters.  
* replace the now() clickhouse funciton by the fixed date to avoid cluster issues
* tables are created with the ReplicatedMergeTree and ON CLUSTER clause in the replication mode
* modified queries to use ON CLUSTER clause. Even if we use a table engine with automatic replication to all nodes of the cluster, this clause (in theory) permit to accelerate the data propagation. 