### PR TITLE
add TagDatabaseGenerator and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
                        
 [maven-image]: https://img.shields.io/maven-central/v/com.mediarithmics/liquibase-clickhouse.svg?maxAge=259200&style=for-the-badge&color=brithgreen&label=com.mediarithmics:liquibase-clickhouse
 [maven-url]: https://search.maven.org/search?q=a:liquibase-clickhouse
+Supported operations: update, rollback (with provided SQL script), tag
+
 
 Maven dependency:
 

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/TagDatabaseGeneratorClickhouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/TagDatabaseGeneratorClickhouse.java
@@ -1,0 +1,93 @@
+/*-
+ * #%L
+ * Liquibase extension for ClickHouse
+ * %%
+ * Copyright (C) 2020 - 2021 Mediarithmics
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package liquibase.ext.clickhouse.sqlgenerator;
+
+import liquibase.ext.clickhouse.database.ClickHouseDatabase;
+import liquibase.ext.clickhouse.params.ClusterConfig;
+import liquibase.ext.clickhouse.params.ParamsLoader;
+
+import liquibase.database.Database;
+import liquibase.datatype.DataTypeFactory;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.TagDatabaseGenerator;
+import liquibase.statement.core.TagDatabaseStatement;
+import liquibase.structure.core.Column;
+
+public class TagDatabaseGeneratorClickhouse extends TagDatabaseGenerator {
+  @Override
+  public int getPriority() {
+    return PRIORITY_DATABASE;
+  }
+
+  @Override
+  public boolean supports(TagDatabaseStatement statement, Database database) {
+    return database instanceof ClickHouseDatabase;
+  }
+
+  @Override
+  public Sql[] generateSql(
+      TagDatabaseStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+    String tableNameEscaped =
+        database.escapeTableName(
+            database.getLiquibaseCatalogName(),
+            database.getLiquibaseSchemaName(),
+            database.getDatabaseChangeLogTableName());
+    ClusterConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
+    String orderColumnNameEscaped = database.escapeObjectName("ORDEREXECUTED", Column.class);
+    String dateColumnNameEscaped = database.escapeObjectName("DATEEXECUTED", Column.class);
+    String tagEscaped =
+        DataTypeFactory.getInstance()
+            .fromObject(statement.getTag(), database)
+            .objectToSql(statement.getTag(), database);
+
+    return new Sql[] {
+      new UnparsedSql(
+          "ALTER TABLE "
+              + tableNameEscaped
+              + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
+              + " UPDATE TAG="
+              + tagEscaped
+              + " WHERE "
+              + dateColumnNameEscaped
+              + "=(SELECT "
+              + dateColumnNameEscaped
+              + " FROM "
+              + tableNameEscaped
+              + " ORDER BY "
+              + dateColumnNameEscaped
+              + " DESC, "
+              + orderColumnNameEscaped
+              + " DESC LIMIT 1)"
+              + " AND "
+              + orderColumnNameEscaped
+              + "=(SELECT "
+              + orderColumnNameEscaped
+              + " FROM "
+              + tableNameEscaped
+              + " ORDER BY "
+              + dateColumnNameEscaped
+              + " DESC, "
+              + orderColumnNameEscaped
+              + " DESC LIMIT 1)")
+    };
+  }
+}

--- a/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
+++ b/src/main/resources/META-INF/services/liquibase.sqlgenerator.SqlGenerator
@@ -6,3 +6,4 @@ liquibase.ext.clickhouse.sqlgenerator.UnlockDatabaseChangelogClickHouse
 liquibase.ext.clickhouse.sqlgenerator.ModifyDataTypeClickHouse
 liquibase.ext.clickhouse.sqlgenerator.RemoveChangeSetRanStatusClickHouse
 liquibase.ext.clickhouse.sqlgenerator.UpdateChangeSetChecksumClickHouse
+liquibase.ext.clickhouse.sqlgenerator.TagDatabaseGeneratorClickhouse

--- a/src/test/java/liquibase/ClickHouseTest.java
+++ b/src/test/java/liquibase/ClickHouseTest.java
@@ -67,11 +67,11 @@ public class ClickHouseTest {
   @Test
   void canTagDatabase() {
     runLiquibase(
-            "changelog.xml",
-            (liquibase, database) -> {
-              liquibase.update("");
-              liquibase.tag("testTag");
-            });
+        "changelog.xml",
+        (liquibase, database) -> {
+          liquibase.update("");
+          liquibase.tag("testTag");
+        });
   }
 
   @Test

--- a/src/test/java/liquibase/ClickHouseTest.java
+++ b/src/test/java/liquibase/ClickHouseTest.java
@@ -65,6 +65,16 @@ public class ClickHouseTest {
   }
 
   @Test
+  void canTagDatabase() {
+    runLiquibase(
+            "changelog.xml",
+            (liquibase, database) -> {
+              liquibase.update("");
+              liquibase.tag("testTag");
+            });
+  }
+
+  @Test
   void canValidate() {
     runLiquibase("changelog.xml", (liquibase, database) -> liquibase.validate());
   }


### PR DESCRIPTION
Liquibase's Tag feature is an important one in order to follow changes on a database in big organisations.
Even though it is not recommended to use ALTER UPDATE statements on a Production environment for clickhouse since it is a heavy operation, in a development phase where datamodel can change very often it is a big help to tag changes and be able to rollback using it.