### PR TITLE
Change pattern of shading relocation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,20 +227,20 @@
                             <shadedClassifierName>shaded</shadedClassifierName>
                             <relocations>
                                 <relocation>
-                                    <pattern>com</pattern>
-                                    <shadedPattern>shaded.liquibase.com</shadedPattern>
+                                    <pattern>com.</pattern>
+                                    <shadedPattern>shaded.liquibase.com.</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>net</pattern>
-                                    <shadedPattern>shaded.liquibase.net</shadedPattern>
+                                    <pattern>net.</pattern>
+                                    <shadedPattern>shaded.liquibase.net.</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org</pattern>
-                                    <shadedPattern>shaded.liquibase.org</shadedPattern>
+                                    <pattern>org.</pattern>
+                                    <shadedPattern>shaded.liquibase.org.</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>ru</pattern>
-                                    <shadedPattern>shaded.liquibase.ru</shadedPattern>
+                                    <pattern>ru.</pattern>
+                                    <shadedPattern>shaded.liquibase.ru.</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION
Related to issue #16:
maven-shade-plugin changes values of string literals in shaded
libraries, so every literal string beginning with a pattern would be
relocated.
In this case in clickhouse-jdbc:
The string "comment" was relocated to "com.shaded.liquibase.comment"

The bug https://issues.apache.org/jira/browse/MSHADE-156 was filed on
the plugin but does not seem on its way to be fixed, so we try the
following workaround: Apply a stronger pattern.