### PR TITLE
Add mutations_sync setting to ALTER statements

### DIFF
--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
@@ -53,7 +53,8 @@ public class LockDatabaseChangeLogClickHouse extends LockDatabaseChangeLogGenera
         String.format(
             "ALTER TABLE %s.%s "
                 + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "UPDATE LOCKED = 1,LOCKEDBY = '%s',LOCKGRANTED = %s WHERE ID = 1 AND LOCKED = 0",
+                + "UPDATE LOCKED = 1,LOCKEDBY = '%s',LOCKGRANTED = %s WHERE ID = 1 AND LOCKED = 0"
+                + " SETTINGS mutations_sync = 1",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogLockTableName(),
             host,

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/RemoveChangeSetRanStatusClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/RemoveChangeSetRanStatusClickHouse.java
@@ -54,7 +54,8 @@ public class RemoveChangeSetRanStatusClickHouse extends RemoveChangeSetRanStatus
         String.format(
             "ALTER TABLE %s.%s "
                 + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "DELETE WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s'",
+                + "DELETE WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s'"
+                + " SETTINGS mutations_sync = 1",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogTableName(),
             changeSet.getId(),

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UnlockDatabaseChangelogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UnlockDatabaseChangelogClickHouse.java
@@ -52,7 +52,8 @@ public class UnlockDatabaseChangelogClickHouse extends UnlockDatabaseChangeLogGe
         String.format(
             "ALTER TABLE %s.%s "
                 + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "UPDATE LOCKED = 0,LOCKEDBY = null, LOCKGRANTED = null WHERE ID = 1 AND LOCKED = 1",
+                + "UPDATE LOCKED = 0,LOCKEDBY = null, LOCKGRANTED = null WHERE ID = 1 AND LOCKED = 1"
+                + " SETTINGS mutations_sync = 1",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogLockTableName());
 

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UpdateChangeSetChecksumClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UpdateChangeSetChecksumClickHouse.java
@@ -54,7 +54,8 @@ public class UpdateChangeSetChecksumClickHouse extends UpdateChangeSetChecksumGe
         String.format(
             "ALTER TABLE %s.%s "
                 + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "UPDATE MD5SUM = '%s' WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s'",
+                + "UPDATE MD5SUM = '%s' WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s'"
+                + " SETTINGS mutations_sync = 1",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogTableName(),
             changeSet.generateCheckSum().toString(),


### PR DESCRIPTION
Since Liquibase is checking the number of affected rows the query needs to run synchronously to avoid exceptions in the log. Fixes issue #23 