### PR TITLE
#27_clickhouse-jdbc-driver upgrade and resolve Transactions are not supported error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -66,10 +67,10 @@
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <clickhouse-jdbc.version>0.3.1</clickhouse-jdbc.version>
-        <liquibase.version>4.6.1</liquibase.version>
+        <clickhouse-jdbc.version>0.3.2</clickhouse-jdbc.version>
+        <liquibase.version>4.15.0</liquibase.version>
         <junit.version>5.4.0</junit.version>
-        <test-containers.version>1.15.3</test-containers.version>
+        <test-containers.version>1.17.3</test-containers.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
@@ -86,7 +87,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>ru.yandex.clickhouse</groupId>
+            <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
             <version>${clickhouse-jdbc.version}</version>
         </dependency>

--- a/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
+++ b/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for Clickhouse
  * %%
- * Copyright (C) 2020 - 2022 Mediarithmics
+ * Copyright (C) 2020 - 2023 Mediarithmics
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,10 @@ package liquibase.ext.clickhouse.database;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import com.clickhouse.jdbc.ClickHouseDriver;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
-import ru.yandex.clickhouse.ClickHouseDriver;
 
 public class ClickHouseDatabase extends AbstractJdbcDatabase {
 
@@ -89,6 +89,11 @@ public class ClickHouseDatabase extends AbstractJdbcDatabase {
 
   @Override
   public boolean supportsSchemas() {
+    return false;
+  }
+
+  @Override
+  public boolean supportsDDLInTransaction() {
     return false;
   }
 }

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/InitializeDatabaseChangeLogLockClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/InitializeDatabaseChangeLogLockClickHouse.java
@@ -54,7 +54,7 @@ public class InitializeDatabaseChangeLogLockClickHouse
         String.format(
             "ALTER TABLE %s.%s "
                 + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "DELETE WHERE 1",
+                + "DELETE WHERE 1 SETTINGS mutations_sync = 1",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogLockTableName());
 

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
@@ -53,7 +53,7 @@ public class LockDatabaseChangeLogClickHouse extends LockDatabaseChangeLogGenera
         String.format(
             "ALTER TABLE %s.%s "
                 + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "UPDATE LOCKED = 1,LOCKEDBY = '%s',LOCKGRANTED = %s WHERE ID = 1 AND LOCKED = 0",
+                + "UPDATE LOCKED = 1,LOCKEDBY = '%s',LOCKGRANTED = %s WHERE ID = 1 AND LOCKED = 0 SETTINGS mutations_sync = 1",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogLockTableName(),
             host,

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/RemoveChangeSetRanStatusClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/RemoveChangeSetRanStatusClickHouse.java
@@ -54,7 +54,7 @@ public class RemoveChangeSetRanStatusClickHouse extends RemoveChangeSetRanStatus
         String.format(
             "ALTER TABLE %s.%s "
                 + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "DELETE WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s'",
+                + "DELETE WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s' SETTINGS mutations_sync = 1",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogTableName(),
             changeSet.getId(),

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/TagDatabaseGeneratorClickhouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/TagDatabaseGeneratorClickhouse.java
@@ -87,7 +87,7 @@ public class TagDatabaseGeneratorClickhouse extends TagDatabaseGenerator {
               + dateColumnNameEscaped
               + " DESC, "
               + orderColumnNameEscaped
-              + " DESC LIMIT 1)")
+              + " DESC LIMIT 1) SETTINGS mutations_sync = 1")
     };
   }
 }

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UnlockDatabaseChangelogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UnlockDatabaseChangelogClickHouse.java
@@ -52,7 +52,7 @@ public class UnlockDatabaseChangelogClickHouse extends UnlockDatabaseChangeLogGe
         String.format(
             "ALTER TABLE %s.%s "
                 + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "UPDATE LOCKED = 0,LOCKEDBY = null, LOCKGRANTED = null WHERE ID = 1 AND LOCKED = 1",
+                + "UPDATE LOCKED = 0,LOCKEDBY = null, LOCKGRANTED = null WHERE ID = 1 AND LOCKED = 1 SETTINGS mutations_sync = 1",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogLockTableName());
 

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UpdateChangeSetChecksumClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UpdateChangeSetChecksumClickHouse.java
@@ -54,7 +54,7 @@ public class UpdateChangeSetChecksumClickHouse extends UpdateChangeSetChecksumGe
         String.format(
             "ALTER TABLE %s.%s "
                 + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "UPDATE MD5SUM = '%s' WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s'",
+                + "UPDATE MD5SUM = '%s' WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s' SETTINGS mutations_sync = 1",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogTableName(),
             changeSet.generateCheckSum().toString(),

--- a/src/test/java/liquibase/ClickHouseTest.java
+++ b/src/test/java/liquibase/ClickHouseTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for Clickhouse
  * %%
- * Copyright (C) 2020 - 2022 Mediarithmics
+ * Copyright (C) 2020 - 2023 Mediarithmics
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public class ClickHouseTest {
 
   @Container
   private static ClickHouseContainer clickHouseContainer =
-      new ClickHouseContainer("yandex/clickhouse-server:20.3");
+      new ClickHouseContainer("clickhouse/clickhouse-server:22.3.8.39");
 
   @Test
   void canInitializeLiquibaseSchema() {


### PR DESCRIPTION
* replace clickhouse-jdbc-driver from ru.yandex.clickhouse(0.3.1) to com.clickhouse(version 0.3.2)
* liquibase version from 4.6.1 to 4.15.0
* testcontainer from 1.15.3 to 1.17.3
* resolve Transactions are not supported error
* Add mutations_sync setting to ALTER statements

ralated https://github.com/MEDIARITHMICS/liquibase-clickhouse/issues/27