### PR TITLE
Use lightweight deletes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,22 +67,23 @@
         <project.build.sourceEncoding>${encoding}</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <clickhouse-jdbc.version>0.3.2</clickhouse-jdbc.version>
-        <liquibase.version>4.15.0</liquibase.version>
-        <junit.version>5.4.0</junit.version>
-        <test-containers.version>1.17.3</test-containers.version>
-        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <clickhouse-jdbc.version>0.4.5</clickhouse-jdbc.version>
+        <liquibase.version>4.21.1</liquibase.version>
+        <junit.version>5.9.2</junit.version>
+        <test-containers.version>1.18.0</test-containers.version>
+        <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
-        <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
         <license-maven-plugin.version>2.0.0</license-maven-plugin.version>
-        <maven-shade-plugin.version>3.2.0</maven-shade-plugin.version>
-        <fmt-maven-plugin.version>2.9.1</fmt-maven-plugin.version>
-        <impsort-maven-plugin.version>1.4.1</impsort-maven-plugin.version>
+        <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
+        <fmt-maven-plugin.version>2.19</fmt-maven-plugin.version>
+        <impsort-maven-plugin.version>1.8.0</impsort-maven-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <snakeyaml.version>1.28</snakeyaml.version>
-        <typesafe-config.version>1.4.1</typesafe-config.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
+        <typesafe-config.version>1.4.2</typesafe-config.version>
+        <lz4.version>1.8.0</lz4.version>
     </properties>
 
     <dependencies>
@@ -124,6 +125,11 @@
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
             <version>${typesafe-config.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>${lz4.version}</version>
         </dependency>
     </dependencies>
 
@@ -249,7 +255,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.coveo</groupId>
+                <groupId>com.spotify.fmt</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>${fmt-maven-plugin.version}</version>
                 <configuration>

--- a/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
+++ b/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
@@ -19,13 +19,15 @@
  */
 package liquibase.ext.clickhouse.database;
 
+import com.clickhouse.jdbc.ClickHouseDriver;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import com.clickhouse.jdbc.ClickHouseDriver;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
+import liquibase.statement.SqlStatement;
+import liquibase.statement.core.RawSqlStatement;
 
 public class ClickHouseDatabase extends AbstractJdbcDatabase {
 
@@ -89,11 +91,16 @@ public class ClickHouseDatabase extends AbstractJdbcDatabase {
 
   @Override
   public boolean supportsSchemas() {
-    return false;
+    return true;
   }
 
   @Override
   public boolean supportsDDLInTransaction() {
     return false;
+  }
+
+
+  @Override protected SqlStatement getConnectionSchemaNameCallStatement() {
+    return new RawSqlStatement("SELECT currentDatabase()");
   }
 }

--- a/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
+++ b/src/main/java/liquibase/ext/clickhouse/database/ClickHouseDatabase.java
@@ -19,10 +19,10 @@
  */
 package liquibase.ext.clickhouse.database;
 
-import com.clickhouse.jdbc.ClickHouseDriver;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import com.clickhouse.jdbc.ClickHouseDriver;
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
@@ -99,8 +99,8 @@ public class ClickHouseDatabase extends AbstractJdbcDatabase {
     return false;
   }
 
-
-  @Override protected SqlStatement getConnectionSchemaNameCallStatement() {
+  @Override
+  protected SqlStatement getConnectionSchemaNameCallStatement() {
     return new RawSqlStatement("SELECT currentDatabase()");
   }
 }

--- a/src/main/java/liquibase/ext/clickhouse/params/ParamsLoader.java
+++ b/src/main/java/liquibase/ext/clickhouse/params/ParamsLoader.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for ClickHouse
  * %%
- * Copyright (C) 2020 - 2022 Mediarithmics
+ * Copyright (C) 2020 - 2023 Mediarithmics
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/CreateDatabaseChangeLogLockTableClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/CreateDatabaseChangeLogLockTableClickHouse.java
@@ -2,7 +2,7 @@
  * #%L
  * Liquibase extension for Clickhouse
  * %%
- * Copyright (C) 2020 - 2022 Mediarithmics
+ * Copyright (C) 2020 - 2023 Mediarithmics
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/InitializeDatabaseChangeLogLockClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/InitializeDatabaseChangeLogLockClickHouse.java
@@ -20,8 +20,6 @@
 package liquibase.ext.clickhouse.sqlgenerator;
 
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
-import liquibase.ext.clickhouse.params.ClusterConfig;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 
 import liquibase.database.Database;
 import liquibase.sql.Sql;
@@ -48,21 +46,12 @@ public class InitializeDatabaseChangeLogLockClickHouse
       InitializeDatabaseChangeLogLockTableStatement statement,
       Database database,
       SqlGeneratorChain sqlGeneratorChain) {
-    ClusterConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
 
     String clearDatabaseQuery =
         String.format(
-            "ALTER TABLE %s.%s "
-                + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "DELETE WHERE 1 SETTINGS mutations_sync = 1",
-            database.getDefaultSchemaName(),
-            database.getDatabaseChangeLogLockTableName());
-
-    String initLockQuery =
-        String.format(
-            "INSERT INTO %s.%s (ID, LOCKED) VALUES (1, 0)",
+            "SET allow_experimental_lightweight_delete = 1; DELETE FROM %s.%s WHERE 1",
             database.getDefaultSchemaName(), database.getDatabaseChangeLogLockTableName());
 
-    return SqlGeneratorUtil.generateSql(database, clearDatabaseQuery, initLockQuery);
+    return SqlGeneratorUtil.generateSql(database, clearDatabaseQuery);
   }
 }

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/LockDatabaseChangeLogClickHouse.java
@@ -20,8 +20,6 @@
 package liquibase.ext.clickhouse.sqlgenerator;
 
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
-import liquibase.ext.clickhouse.params.ClusterConfig;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 
 import liquibase.database.Database;
 import liquibase.sql.Sql;
@@ -46,14 +44,11 @@ public class LockDatabaseChangeLogClickHouse extends LockDatabaseChangeLogGenera
       LockDatabaseChangeLogStatement statement,
       Database database,
       SqlGeneratorChain sqlGeneratorChain) {
-    ClusterConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
 
     String host = String.format("%s %s (%s)", hostname, hostDescription, hostaddress);
     String lockQuery =
         String.format(
-            "ALTER TABLE %s.%s "
-                + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "UPDATE LOCKED = 1,LOCKEDBY = '%s',LOCKGRANTED = %s WHERE ID = 1 AND LOCKED = 0 SETTINGS mutations_sync = 1",
+            "INSERT INTO %s.%s (ID, LOCKED, LOCKEDBY, LOCKGRANTED) VALUES (1, 1, '%s', %s)",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogLockTableName(),
             host,

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/RemoveChangeSetRanStatusClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/RemoveChangeSetRanStatusClickHouse.java
@@ -20,8 +20,6 @@
 package liquibase.ext.clickhouse.sqlgenerator;
 
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
-import liquibase.ext.clickhouse.params.ClusterConfig;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 
 import liquibase.changelog.ChangeSet;
 import liquibase.database.Database;
@@ -47,14 +45,12 @@ public class RemoveChangeSetRanStatusClickHouse extends RemoveChangeSetRanStatus
       RemoveChangeSetRanStatusStatement statement,
       Database database,
       SqlGeneratorChain sqlGeneratorChain) {
-    ClusterConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
 
     ChangeSet changeSet = statement.getChangeSet();
     String unlockQuery =
         String.format(
-            "ALTER TABLE %s.%s "
-                + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "DELETE WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s' SETTINGS mutations_sync = 1",
+            "SET allow_experimental_lightweight_delete = 1;"
+                + "DELETE FROM %s.%s WHERE ID = '%s' AND AUTHOR = '%s' AND FILENAME = '%s'",
             database.getDefaultSchemaName(),
             database.getDatabaseChangeLogTableName(),
             changeSet.getId(),

--- a/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UnlockDatabaseChangelogClickHouse.java
+++ b/src/main/java/liquibase/ext/clickhouse/sqlgenerator/UnlockDatabaseChangelogClickHouse.java
@@ -20,8 +20,6 @@
 package liquibase.ext.clickhouse.sqlgenerator;
 
 import liquibase.ext.clickhouse.database.ClickHouseDatabase;
-import liquibase.ext.clickhouse.params.ClusterConfig;
-import liquibase.ext.clickhouse.params.ParamsLoader;
 
 import liquibase.database.Database;
 import liquibase.sql.Sql;
@@ -46,15 +44,11 @@ public class UnlockDatabaseChangelogClickHouse extends UnlockDatabaseChangeLogGe
       UnlockDatabaseChangeLogStatement statement,
       Database database,
       SqlGeneratorChain sqlGeneratorChain) {
-    ClusterConfig properties = ParamsLoader.getLiquibaseClickhouseProperties();
 
     String unlockQuery =
         String.format(
-            "ALTER TABLE %s.%s "
-                + SqlGeneratorUtil.generateSqlOnClusterClause(properties)
-                + "UPDATE LOCKED = 0,LOCKEDBY = null, LOCKGRANTED = null WHERE ID = 1 AND LOCKED = 1 SETTINGS mutations_sync = 1",
-            database.getDefaultSchemaName(),
-            database.getDatabaseChangeLogLockTableName());
+            "SET allow_experimental_lightweight_delete = 1; DELETE FROM %s.%s WHERE ID = 1;",
+            database.getDefaultSchemaName(), database.getDatabaseChangeLogLockTableName());
 
     return SqlGeneratorUtil.generateSql(database, unlockQuery);
   }

--- a/src/test/java/liquibase/ClickHouseTest.java
+++ b/src/test/java/liquibase/ClickHouseTest.java
@@ -37,7 +37,7 @@ public class ClickHouseTest {
 
   @Container
   private static ClickHouseContainer clickHouseContainer =
-      new ClickHouseContainer("clickhouse/clickhouse-server:22.3.8.39");
+      new ClickHouseContainer("clickhouse/clickhouse-server:23.3");
 
   @Test
   void canInitializeLiquibaseSchema() {


### PR DESCRIPTION
Change lock logic to use lightweight deletes to improve performance on
heavily loaded clusters.

Using mutations_sync waits until mutation is finished on all nodes.
Using lightweight deletes (in Clickhouse since 22.8) is a lot quicker.